### PR TITLE
Refactoring

### DIFF
--- a/showWeather/showWeather/APIMangaer/APIManager.swift
+++ b/showWeather/showWeather/APIMangaer/APIManager.swift
@@ -109,6 +109,7 @@ class APIManager {
     // Rx+URLSession
     func getData(nx: Int, ny: Int, convenience: Bool) -> Observable<WeatherDataModel> {
         return getUrls(nx: nx, ny: ny, convenience: convenience)
+            .debug("getData")
             .share()
             .map{ url in
                 return URLRequest(url: url.url!)

--- a/showWeather/showWeather/APIMangaer/APIManager.swift
+++ b/showWeather/showWeather/APIMangaer/APIManager.swift
@@ -6,6 +6,8 @@
 //
 
 import Foundation
+import RxSwift
+import RxCocoa
 
 // 위도 경도 변환 데이터 모델
 struct LatXLngY {
@@ -29,7 +31,8 @@ enum NetworkError: Error {
 class APIManager {
     static let shared = APIManager()
     init() {}
-
+    
+    private let disposeBag = DisposeBag()
     // 변환된 x,y좌표의 url파싱
     private func getUrl(convenience: Bool, nx: Int, ny: Int) -> [URLComponents] {
         let scheme = "https"
@@ -51,8 +54,6 @@ class APIManager {
         timeFormatter.dateFormat = "HHmm"
         let baseDate = dateFormatter.string(from: now)
         let baseTime = timeFormatter.string(from: before)
-        print("current: \(dateFormatter.string(from: now))")
-        print("current: \(timeFormatter.string(from: before))")
         
         guard let url = Bundle.main.url(forResource: "Info", withExtension: "plist") else { return []}
         guard let dictionary = NSDictionary(contentsOf: url) else { return []}
@@ -94,11 +95,90 @@ class APIManager {
     private let session = URLSession(configuration: .default)
     typealias NetworkResult = (Result<WeatherDataModel, NetworkError>) -> ()
     
-    // URLSession GET Data
+    // MARK: Rx + URLSession
+    private func getUrls(convenience: Bool, nx: Int, ny: Int) -> Observable<URLComponents> {
+        return Observable.create { observer in
+            let scheme = "https"
+            let host = "apis.data.go.kr"
+            let path = "/1360000/VilageFcstInfoService_2.0/getUltraSrtFcst"
+            
+            var arr = [URLComponents]()
+            var components = URLComponents()
+            components.scheme = scheme
+            components.host = host
+            components.path = path
+            
+            // 현재날짜와 시간 구하기
+            let now = Date()
+            let before = Calendar.current.date(byAdding: .minute, value: -30, to: now)!
+            let dateFormatter = DateFormatter()
+            let timeFormatter = DateFormatter()
+            dateFormatter.dateFormat = "yyyyMMdd"
+            timeFormatter.dateFormat = "HHmm"
+            let baseDate = dateFormatter.string(from: now)
+            let baseTime = timeFormatter.string(from: before)
+            
+            guard let url = Bundle.main.url(forResource: "Info", withExtension: "plist") else {
+                print("Error:: can't find api key")
+                return Disposables.create()
+            }
+            guard let dictionary = NSDictionary(contentsOf: url) else {
+                print("Error:: api key doesn't loaded")
+                return Disposables.create()
+            }
+            
+            // convenience true: URLSession 한번 통신, false: 두번 통신
+            if convenience {
+                components.percentEncodedQueryItems = [
+                    URLQueryItem(name: "serviceKey", value: dictionary["ApiKey"] as! String),
+                    URLQueryItem(name: "numOfRows", value: "30"),
+                    URLQueryItem(name: "pageNo", value: "1"),
+                    URLQueryItem(name: "dataType", value: "JSON"),
+                    URLQueryItem(name: "base_date", value: baseDate),
+                    URLQueryItem(name: "base_time", value: baseTime),
+                    URLQueryItem(name: "nx", value: String(nx)),
+                    URLQueryItem(name: "ny", value: String(ny))
+                ]
+//                arr.append(components)
+                observer.onNext(components)
+            } else {
+                // 총 데이터수는 60개지만 1회호출로 가져올 수 있는 데이터의 최대갯수는 50개이므로 두번 걸쳐서 받기위해 URLComponents를 배열로 담아서 리턴
+                for i in 1...2 {
+                    components.percentEncodedQueryItems = [
+                        URLQueryItem(name: "serviceKey", value: dictionary["ApiKey"] as! String),
+                        URLQueryItem(name: "numOfRows", value: "30"),
+                        URLQueryItem(name: "pageNo", value: String(i)),
+                        URLQueryItem(name: "dataType", value: "JSON"),
+                        URLQueryItem(name: "base_date", value: baseDate),
+                        URLQueryItem(name: "base_time", value: baseTime),
+                        URLQueryItem(name: "nx", value: String(nx)),
+                        URLQueryItem(name: "ny", value: String(ny))
+                    ]
+                    observer.onNext(components)
+                }
+            }
+            return Disposables.create()
+        }
+    }
+    func getData(nx: Int, ny: Int, convenience: Bool) -> Observable<WeatherDataModel> {
+        return getUrls(convenience: convenience, nx: nx, ny: ny)
+            .map{ url in
+                return URLRequest(url: url.url!)
+            }
+            .flatMap { request -> Observable<(response: HTTPURLResponse, data: Data)> in
+                return URLSession.shared.rx.response(request: request)
+            }.share()
+            .map{ _, data -> WeatherDataModel in
+                let decoder = JSONDecoder()
+                let decoded = try? decoder.decode(WeatherDataModel.self, from: data)
+                return decoded ?? WeatherDataModel(response: DataResponse(header: ResponseHeader(resultCode: "04"), body: nil))
+            }
+    }
+    
+    // MARK: URLSession GET Data
     func dataFetch(nx: Int, ny: Int, convenience: Bool, completion: @escaping NetworkResult) {
         // URL 확인
         let urls = getUrl(convenience: convenience, nx: nx, ny: ny)
-//        let urls = getUrl(nx: nx, ny: ny)
         for url in urls {
             guard let url = url.url else {
                 completion(.failure(.invalidUrl))
@@ -106,7 +186,6 @@ class APIManager {
             }
             var request: URLRequest = URLRequest(url: url)
             request.httpMethod = "GET"
-            print("APIManager:: URL: \(url)")
             let dataTask = session.dataTask(with: request) { data, response, error in
                 // 연결 확인
                 guard error == nil else {
@@ -126,7 +205,6 @@ class APIManager {
                     completion(.failure(.missingData))
                     return
                 }
-                print("loadData: \(loadData)")
                 // 디코딩
                 do {
                     let parsingData: WeatherDataModel = try

--- a/showWeather/showWeather/Controllers/SearchResultViewController.swift
+++ b/showWeather/showWeather/Controllers/SearchResultViewController.swift
@@ -7,129 +7,101 @@
 
 import UIKit
 import MapKit
+import RxSwift
+import RxCocoa
+
 protocol SearchResultViewControllerDelegate: AnyObject {
     func didTappedAddButtonFromWeatherVC(data: LocationWeatherDataModel)
 }
-class SearchResultViewController: UIViewController {
+
+class SearchResultViewController: UISearchController {
+    
+    //    MARK: Property
+    private let disposeBag = DisposeBag()
     private lazy var viewModel: SearchResultViewModel = {
         let vm = SearchResultViewModel()
-        vm.delegate = self
         return vm
     }()
     private lazy var searchCompleter: MKLocalSearchCompleter? = {
         let completer = MKLocalSearchCompleter()
-        completer.delegate = self
         completer.region = self.searchRegion
         return completer
     }()
-    private let searchRegion: MKCoordinateRegion = MKCoordinateRegion(MKMapRect.world)
+    private let searchRegion = MKCoordinateRegion(center: CLLocationCoordinate2D(latitude: 37.5666791, longitude: 126.9782914), span: MKCoordinateSpan(latitudeDelta: 0.5, longitudeDelta: 0.5))
     private var completerResults: [MKLocalSearchCompletion]?
-    weak var delegate: SearchResultViewControllerDelegate?
-//    MARK: UI Property
     private lazy var tableView: UITableView = {
         let tv = UITableView()
-        tv.dataSource = self
         tv.delegate = self
         tv.translatesAutoresizingMaskIntoConstraints = false
         tv.register(SearchResultTableViewCell.self, forCellReuseIdentifier: SearchResultTableViewCell.identifier)
         tv.estimatedRowHeight = 50
         return tv
     }()
-//    MARK: Methods
-    private func addViews() {
-        self.view.addSubview(tableView)
-    }
-    private func configureLayout() {
-        NSLayoutConstraint.activate([
-            tableView.topAnchor.constraint(equalTo: self.view.topAnchor),
-            tableView.bottomAnchor.constraint(equalTo: self.view.bottomAnchor),
-            tableView.leadingAnchor.constraint(equalTo: self.view.leadingAnchor),
-            tableView.trailingAnchor.constraint(equalTo: self.view.trailingAnchor),
-        ])
-    }
-    private func configureColor() {
-        self.tableView.backgroundColor = UIColor(named: "ViewControllerBackgroundColor")
-        self.view.backgroundColor = UIColor(named: "ViewControllerBackgroundColor")
-    }
+    
+   // MARK: ViewDidLoad
     override func viewDidLoad() {
         super.viewDidLoad()
         addViews()
         configureLayout()
-        print("SearchResultViewController ViewdidLoad")
+        
+        // UISearchResultsUpdating 바인딩
+        self.rx.searchPhrase
+            .bind(to: searchCompleter!.rx.queryFragment)
+            .disposed(by: disposeBag)
+        
+        // UISearchResultsUpdating가 바인딩되어 값이 변경될 시 구독칸의 함수가 실행됨
+        searchCompleter!.rx.didUpdateResults
+            .debug("searchCompleter")
+            .subscribe {[weak self] completer in
+                self?.completerResults = completer.element?.results
+                self?.viewModel.fetchData(completer.element?.results)
+            }
+            .disposed(by: disposeBag)
+        
+        // 위 바인딩에서 실행된 fetchData에 의해 데이터모델이 변경되고 변경된 모델에 맞춰서 tableViewCell과 바인딩
+        viewModel.element
+            .observe(on: MainScheduler.instance)
+            .debug("viewModel.obs")
+            .bind(to: tableView.rx.items(cellIdentifier: SearchResultTableViewCell.identifier, cellType: SearchResultTableViewCell.self)) { index, element, cell in
+                cell.configure(model: element)
+            }
+            .disposed(by: disposeBag)
+        
+        // tableViewCell 선택시 해당 값을 받고 WeatherViewController 이동
+        tableView.rx.itemSelected
+            .subscribe(onNext: {[weak self] indexPath in
+                guard let self = self,
+                      let suggestion = self.completerResults?[indexPath.row] else { return }
+                let vm = WeatherViewModel(address: viewModel.element.value[indexPath.row].addressLabel, completion: suggestion)
+                let vc = WeatherViewController(viewModel: vm)
+                let navigationController = UINavigationController(rootViewController: vc)
+                self.present(navigationController, animated: true)
+            })
+            .disposed(by: disposeBag)
     }
 }
-// MARK: TableView Delegate, Datasource
-extension SearchResultViewController: UITableViewDelegate, UITableViewDataSource {
-    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return viewModel.elementsCount
-    }
+// MARK: TableView Delegate
+extension SearchResultViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
         return UITableView.automaticDimension
     }
-    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        guard let cell = tableView.dequeueReusableCell(withIdentifier: SearchResultTableViewCell.identifier, for: indexPath) as? SearchResultTableViewCell else { return UITableViewCell()}
-        cell.configure(model: viewModel.elements[indexPath.row])
-        cell.backgroundColor = UIColor(named: "TableViewCellBackgroundColor")
-        return cell
-    }
-    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        tableView.deselectRow(at: indexPath, animated: true)
-        guard let suggestion = completerResults?[indexPath.row] else { return }
-        let vm = WeatherViewModel(address: viewModel.elements[indexPath.row].addressLabel, completion: suggestion)
-        let vc = WeatherViewController(viewModel: vm)
-        let navigationController = UINavigationController(rootViewController: vc)
-        vc.delegate = self
-        self.present(navigationController, animated: true)
-    }
-    
-}
-// MARK: UISearchController:: UISearchResultsUpdating
-extension SearchResultViewController: UISearchResultsUpdating {
-    func updateSearchResults(for searchController: UISearchController) {
-        guard let text = searchController.searchBar.text else { return }
-        print("SRVC:: text: \(text)")
-        if text == "" {
-            completerResults = nil
-        }
-        searchCompleter?.queryFragment = text
-    }
 }
 
-extension SearchResultViewController: UISearchControllerDelegate {
-    func didDismissSearchController(_ searchController: UISearchController) {
-        completerResults = nil
-        viewModel.removeAllElements()
-        print("SearchVC dismiss")
-    }
-}
-// MARK: MKLocalSearchCompleterDelegate
-extension SearchResultViewController: MKLocalSearchCompleterDelegate {
-    func completerDidUpdateResults(_ completer: MKLocalSearchCompleter) {
-        completerResults = completer.results
-        guard let arr = completerResults else { return }
-        viewModel.fetchData(arr)
-    }
-    func completer(_ completer: MKLocalSearchCompleter, didFailWithError error: Error) {
-        print(error.localizedDescription)
-    }
-}
-// MARK: SearchResultViewModelDelegate
-extension SearchResultViewController: SearchResultViewModelDelegate {
-    func didChangedElements() {
-        DispatchQueue.main.async {
-            self.tableView.reloadData()
+// MARK: UI Methods
+extension SearchResultViewController {
+        private func addViews() {
+            self.view.addSubview(tableView)
         }
-    }
-}
-
-extension SearchResultViewController: WeatherViewControllerDelegate {
-    func addButtonTapped(data: LocationWeatherDataModel) {
-        print("WVC Delegate")
-        DispatchQueue.main.async {
-            self.tableView.reloadData()
-            self.dismiss(animated: false)
+        private func configureLayout() {
+            NSLayoutConstraint.activate([
+                tableView.topAnchor.constraint(equalTo: self.view.topAnchor),
+                tableView.bottomAnchor.constraint(equalTo: self.view.bottomAnchor),
+                tableView.leadingAnchor.constraint(equalTo: self.view.leadingAnchor),
+                tableView.trailingAnchor.constraint(equalTo: self.view.trailingAnchor),
+            ])
         }
-        delegate?.didTappedAddButtonFromWeatherVC(data: data)
-    }
+        private func configureColor() {
+            self.tableView.backgroundColor = UIColor(named: "ViewControllerBackgroundColor")
+            self.view.backgroundColor = UIColor(named: "ViewControllerBackgroundColor")
+        }
 }
-

--- a/showWeather/showWeather/Controllers/SearchResultViewController.swift
+++ b/showWeather/showWeather/Controllers/SearchResultViewController.swift
@@ -45,8 +45,8 @@ class SearchResultViewController: UISearchController {
         addViews()
         configureLayout()
         
-        // UISearchController dismiss시 값 초기화
-        self.rx.didDismiss
+        // UISearchController willPresent시 값 초기화
+        self.rx.willPresent
             .subscribe(onNext: { [weak self] in
                 self?.viewModel.removeAllElements()
             })
@@ -69,7 +69,7 @@ class SearchResultViewController: UISearchController {
         // 위 바인딩에서 실행된 fetchData에 의해 데이터모델이 변경되고 변경된 모델에 맞춰서 tableViewCell과 바인딩
         viewModel.element
             .observe(on: MainScheduler.instance)
-            .debug("viewModel.obs")
+            .debug("viewModel.element")
             .bind(to: tableView.rx.items(cellIdentifier: SearchResultTableViewCell.identifier, cellType: SearchResultTableViewCell.self)) { index, element, cell in
                 cell.configure(model: element)
             }

--- a/showWeather/showWeather/Controllers/ViewController.swift
+++ b/showWeather/showWeather/Controllers/ViewController.swift
@@ -10,9 +10,9 @@ import RxSwift
 import RxCocoa
 
 class ViewController: UIViewController {
+    //    MARK: Property
     private let viewModel = ViewModel()
     private let disposeBag = DisposeBag()
-//    MARK: UI Property
     private lazy var collectionView: UICollectionView = {
         let flowlayout = UICollectionViewFlowLayout()
         flowlayout.scrollDirection = .vertical
@@ -24,6 +24,8 @@ class ViewController: UIViewController {
         
         return cv
     }()
+    
+    // MARK: viewDidLoad
     override func viewDidLoad() {
         super.viewDidLoad()
         configureNavigationBar()
@@ -38,6 +40,22 @@ class ViewController: UIViewController {
                 cell.configure(model: model)
             }
             .disposed(by: disposeBag)
+        
+        collectionView.rx.itemSelected
+            .subscribe(onNext: { [weak self] indexPath in
+                guard let data = self?.viewModel.savedWeather.value[indexPath.row] else { return }
+                self?.moveToWeatherVC(data: data)
+            })
+            .disposed(by: disposeBag)
+    }
+    
+    private func moveToWeatherVC(data: LocationWeatherDataModel) {
+        guard let nx = Int(data.location.nx),
+              let ny = Int(data.location.ny) else { return }
+        let vm = WeatherViewModel(address: data.address, completion: nil)
+        let vc = WeatherViewController(viewModel: vm)
+        vc.viewModel?.fetchDataFromViewController(nx: nx, ny: ny)
+        self.present(vc, animated: true)
     }
 }
 
@@ -50,16 +68,6 @@ extension ViewController: UICollectionViewDelegate, UICollectionViewDelegateFlow
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, insetForSectionAt section: Int) -> UIEdgeInsets {
         return UIEdgeInsets(top: 15, left: 0, bottom: 15, right: 0)
     }
-    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        let data = viewModel.savedWeather.value[indexPath.row]
-        let nx = Int(data.location.nx)!
-        let ny = Int(data.location.ny)!
-        let vm = WeatherViewModel(address: data.address, completion: nil)
-        let vc = WeatherViewController(viewModel: vm)
-        vc.viewModel?.fetchDataFromViewController(nx: nx, ny: ny)
-        self.present(vc, animated: true)
-    }
-    
 }
 
 // MARK: - SearchResultViewControllerDelegate

--- a/showWeather/showWeather/Controllers/ViewController.swift
+++ b/showWeather/showWeather/Controllers/ViewController.swift
@@ -82,7 +82,9 @@ extension ViewController {
         self.navigationController?.navigationBar.isTranslucent = true
         self.navigationItem.hidesSearchBarWhenScrolling = false
         self.navigationItem.title = "날씨"
-        self.navigationItem.searchController = SearchResultViewController()
+        let searchController = SearchResultViewController()
+        searchController.searchResultVCDelegate = self
+        self.navigationItem.searchController = searchController
     }
     private func addViews() {
         view.addSubview(collectionView)

--- a/showWeather/showWeather/Controllers/ViewController.swift
+++ b/showWeather/showWeather/Controllers/ViewController.swift
@@ -6,27 +6,71 @@
 //
 
 import UIKit
+import RxSwift
+import RxCocoa
 
 class ViewController: UIViewController {
-    private lazy var viewModel: ViewModel = {
-        let vm = ViewModel()
-        vm.delegate = self
-        return vm
-    }()
+    private let viewModel = ViewModel()
+    private let disposeBag = DisposeBag()
 //    MARK: UI Property
     private lazy var collectionView: UICollectionView = {
         let flowlayout = UICollectionViewFlowLayout()
         flowlayout.scrollDirection = .vertical
         flowlayout.sectionHeadersPinToVisibleBounds = true
         let cv = UICollectionView(frame: .zero, collectionViewLayout: flowlayout)
-        cv.dataSource = self
         cv.delegate = self
         cv.translatesAutoresizingMaskIntoConstraints = false
         cv.register(CollectionViewCell.self, forCellWithReuseIdentifier: CollectionViewCell.identifier)
         
         return cv
     }()
-//    MARK: Methods
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        configureNavigationBar()
+        addViews()
+        configureLayout()
+        
+        // ViewModel의 savedWeather과 collectionView 바인딩
+        viewModel.savedWeather
+            .observe(on: MainScheduler.instance)
+            .bind(to: collectionView.rx.items(cellIdentifier: CollectionViewCell.identifier, cellType: CollectionViewCell.self)) { index, element, cell in
+                guard let model = element.savedDataModel else  { return }
+                cell.configure(model: model)
+            }
+            .disposed(by: disposeBag)
+    }
+}
+
+// MARK: UICollectionView Delegate, DataSource, FlowLayoutDelegate
+extension ViewController: UICollectionViewDelegate, UICollectionViewDelegateFlowLayout {
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+        let width = self.view.frame.width
+        return CGSize(width: width - 40, height: 80)
+    }
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, insetForSectionAt section: Int) -> UIEdgeInsets {
+        return UIEdgeInsets(top: 15, left: 0, bottom: 15, right: 0)
+    }
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        let data = viewModel.savedWeather.value[indexPath.row]
+        let nx = Int(data.location.nx)!
+        let ny = Int(data.location.ny)!
+        let vm = WeatherViewModel(address: data.address, completion: nil)
+        let vc = WeatherViewController(viewModel: vm)
+        vc.viewModel?.fetchDataFromViewController(nx: nx, ny: ny)
+        self.present(vc, animated: true)
+    }
+    
+}
+
+// MARK: - SearchResultViewControllerDelegate
+extension ViewController: SearchResultViewControllerDelegate {
+    func didTappedAddButtonFromWeatherVC(data: LocationWeatherDataModel) {
+        viewModel.saveData(model: data)
+    }
+}
+
+// MARK: - UI Property Method
+extension ViewController {
     private func configureNavigationBar() {
         let appearance = UINavigationBarAppearance()
         appearance.largeTitleTextAttributes = [NSAttributedString.Key.foregroundColor: UIColor(named: "LabelTextColor")]
@@ -59,63 +103,5 @@ class ViewController: UIViewController {
     private func configureColor() {
         self.view.backgroundColor = UIColor(named: "ViewControllerBackgroundColor")
         self.collectionView.backgroundColor = UIColor(named: "ViewControllerBackgroundColor")
-    }
-    override func viewDidLoad() {
-        super.viewDidLoad()
-        configureNavigationBar()
-        addViews()
-        configureLayout()
-    }
-}
-
-// MARK: UICollectionView Delegate, DataSource, FlowLayoutDelegate
-extension ViewController: UICollectionViewDataSource, UICollectionViewDelegate, UICollectionViewDelegateFlowLayout {
-    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        return viewModel.savedWeathers.count
-    }
-    
-    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: CollectionViewCell.identifier,
-                                                            for: indexPath)
-                                                            as? CollectionViewCell else {
-                                                            return UICollectionViewCell()}
-        cell.backgroundColor = UIColor(named: "CollectionViewCellBackgroundColor")
-        cell.clipsToBounds = true
-        cell.layer.cornerRadius = 10
-        cell.configure(model: viewModel.savedWeathers[indexPath.row])
-        return cell
-    }
-    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
-        let width = self.view.frame.width
-        return CGSize(width: width - 40, height: 80)
-    }
-    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, insetForSectionAt section: Int) -> UIEdgeInsets {
-        return UIEdgeInsets(top: 15, left: 0, bottom: 15, right: 0)
-    }
-    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        let data = viewModel.savedLocationWeatherDataModel[indexPath.row]
-        let nx = Int(data.location.nx)!
-        let ny = Int(data.location.ny)!
-        let vm = WeatherViewModel(address: data.address, completion: nil)
-        let vc = WeatherViewController(viewModel: vm)
-        vc.viewModel?.fetchDataFromViewController(nx: nx, ny: ny)
-        self.present(vc, animated: true)
-    }
-    
-}
-
-// MARK: - SearchResultViewControllerDelegate
-extension ViewController: SearchResultViewControllerDelegate {
-    func didTappedAddButtonFromWeatherVC(data: LocationWeatherDataModel) {
-        viewModel.savedLocationWeatherDataModel.append(data)
-    }
-}
-
-// MARK: - ViewModelDelegate
-extension ViewController: ViewModelDelegate {
-    func savedWeathersUpdated() {
-        DispatchQueue.main.async { [weak self] in
-            self?.collectionView.reloadData()
-        }
     }
 }

--- a/showWeather/showWeather/Controllers/ViewController.swift
+++ b/showWeather/showWeather/Controllers/ViewController.swift
@@ -41,7 +41,7 @@ class ViewController: UIViewController {
     }
 }
 
-// MARK: UICollectionView Delegate, DataSource, FlowLayoutDelegate
+// MARK: UICollectionView Delegate, FlowLayoutDelegate
 extension ViewController: UICollectionViewDelegate, UICollectionViewDelegateFlowLayout {
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
         let width = self.view.frame.width
@@ -82,12 +82,7 @@ extension ViewController {
         self.navigationController?.navigationBar.isTranslucent = true
         self.navigationItem.hidesSearchBarWhenScrolling = false
         self.navigationItem.title = "날씨"
-        let resultViewController = SearchResultViewController()
-        resultViewController.delegate = self
-        let searchController = UISearchController(searchResultsController: resultViewController)
-        searchController.delegate = resultViewController
-        searchController.searchResultsUpdater = resultViewController
-        self.navigationItem.searchController = searchController
+        self.navigationItem.searchController = SearchResultViewController()
     }
     private func addViews() {
         view.addSubview(collectionView)

--- a/showWeather/showWeather/Controllers/WeatherViewController.swift
+++ b/showWeather/showWeather/Controllers/WeatherViewController.swift
@@ -105,60 +105,6 @@ class WeatherViewController: UIViewController {
         return cv
     }()
     
-//    MARK: Methods
-    private func configureNavigationBar() {
-        self.navigationItem.leftBarButtonItem = UIBarButtonItem(title: "취소", image: nil, target: self, action: #selector(cancelButtonTapped))
-        self.navigationItem.rightBarButtonItem = UIBarButtonItem(title: "추가", image: nil, target: self, action: #selector(addLocationWeather))
-    }
-    @objc func addLocationWeather() {
-        guard let viewModel = viewModel,
-              let data = viewModel.getLocationDataModel() else { return }
-        delegate?.addButtonTapped(data: data)
-        self.dismiss(animated: true)
-    }
-    @objc func cancelButtonTapped() {
-        self.dismiss(animated: true)
-    }
-    private func addViews() {
-        rainStackView.addArrangedSubview(rainTypeLabel)
-        rainStackView.addArrangedSubview(rainAmountLabel)
-        humidityStackView.addArrangedSubview(windLabel)
-        humidityStackView.addArrangedSubview(humidity)
-        contentStackView.addArrangedSubview(addressLabel)
-        contentStackView.addArrangedSubview(temperatureLabel)
-        contentStackView.addArrangedSubview(skyImageView)
-        contentStackView.addArrangedSubview(rainStackView)
-        contentStackView.addArrangedSubview(humidityStackView)
-        view.addSubview(contentStackView)
-        view.addSubview(collectionView)
-    }
-    private func configureLayout() {
-        NSLayoutConstraint.activate([
-            contentStackView.topAnchor.constraint(equalTo: self.view.topAnchor, constant: 50),
-            contentStackView.leadingAnchor.constraint(equalTo: self.view.leadingAnchor),
-            contentStackView.trailingAnchor.constraint(equalTo: self.view.trailingAnchor),
-            contentStackView.bottomAnchor.constraint(equalTo: collectionView.topAnchor, constant: -20),
-            collectionView.heightAnchor.constraint(equalToConstant: 200),
-            collectionView.leadingAnchor.constraint(equalTo: self.view.leadingAnchor,constant: 20),
-            collectionView.trailingAnchor.constraint(equalTo: self.view.trailingAnchor, constant: -20),
-            collectionView.bottomAnchor.constraint(equalTo: self.view.bottomAnchor,constant: -50),
-
-        ])
-    }
-    private func configureColor() {
-        self.addressLabel.textColor = UIColor(named: "LabelTextColor")
-        self.temperatureLabel.textColor = UIColor(named: "LabelTextColor")
-        self.rainTypeLabel.textColor = UIColor(named: "LabelTextColor")
-        self.rainAmountLabel.textColor = UIColor(named: "LabelTextColor")
-        self.windLabel.textColor = UIColor(named: "LabelTextColor")
-        self.humidity.textColor = UIColor(named: "LabelTextColor")
-        self.contentStackView.backgroundColor = UIColor(named: "ViewControllerBackgroundColor")
-        self.rainStackView.backgroundColor = UIColor(named: "ViewControllerBackgroundColor")
-        self.humidityStackView.backgroundColor = UIColor(named: "ViewControllerBackgroundColor")
-        self.collectionView.backgroundColor = UIColor(named: "CollectionViewCellBackgroundColor")
-        self.view.backgroundColor = UIColor(named: "ViewControllerBackgroundColor")
-    }
-
     // MARK: viewDidLoad
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -172,6 +118,8 @@ class WeatherViewController: UIViewController {
             .observe(on: MainScheduler.instance)
             .asObservable()
             .subscribe(onNext: { [weak self] model in
+                print("viewModel bind")
+                print("model: \(model)")
                 self?.configureTexts(model: model)
             })
             .disposed(by: disposeBag)
@@ -197,6 +145,59 @@ extension WeatherViewController: UICollectionViewDelegate, UICollectionViewDeleg
 
 // MARK: UI 그리기
 extension WeatherViewController {
+    //    MARK: Methods
+        private func configureNavigationBar() {
+            self.navigationItem.leftBarButtonItem = UIBarButtonItem(title: "취소", image: nil, target: self, action: #selector(cancelButtonTapped))
+            self.navigationItem.rightBarButtonItem = UIBarButtonItem(title: "추가", image: nil, target: self, action: #selector(addLocationWeather))
+        }
+        @objc func addLocationWeather() {
+            guard let viewModel = viewModel,
+                  let data = viewModel.getLocationDataModel() else { return }
+            delegate?.addButtonTapped(data: data)
+            self.dismiss(animated: true)
+        }
+        @objc func cancelButtonTapped() {
+            self.dismiss(animated: true)
+        }
+        private func addViews() {
+            rainStackView.addArrangedSubview(rainTypeLabel)
+            rainStackView.addArrangedSubview(rainAmountLabel)
+            humidityStackView.addArrangedSubview(windLabel)
+            humidityStackView.addArrangedSubview(humidity)
+            contentStackView.addArrangedSubview(addressLabel)
+            contentStackView.addArrangedSubview(temperatureLabel)
+            contentStackView.addArrangedSubview(skyImageView)
+            contentStackView.addArrangedSubview(rainStackView)
+            contentStackView.addArrangedSubview(humidityStackView)
+            view.addSubview(contentStackView)
+            view.addSubview(collectionView)
+        }
+        private func configureLayout() {
+            NSLayoutConstraint.activate([
+                contentStackView.topAnchor.constraint(equalTo: self.view.topAnchor, constant: 50),
+                contentStackView.leadingAnchor.constraint(equalTo: self.view.leadingAnchor),
+                contentStackView.trailingAnchor.constraint(equalTo: self.view.trailingAnchor),
+                contentStackView.bottomAnchor.constraint(equalTo: collectionView.topAnchor, constant: -20),
+                collectionView.heightAnchor.constraint(equalToConstant: 200),
+                collectionView.leadingAnchor.constraint(equalTo: self.view.leadingAnchor,constant: 20),
+                collectionView.trailingAnchor.constraint(equalTo: self.view.trailingAnchor, constant: -20),
+                collectionView.bottomAnchor.constraint(equalTo: self.view.bottomAnchor,constant: -50),
+
+            ])
+        }
+        private func configureColor() {
+            self.addressLabel.textColor = UIColor(named: "LabelTextColor")
+            self.temperatureLabel.textColor = UIColor(named: "LabelTextColor")
+            self.rainTypeLabel.textColor = UIColor(named: "LabelTextColor")
+            self.rainAmountLabel.textColor = UIColor(named: "LabelTextColor")
+            self.windLabel.textColor = UIColor(named: "LabelTextColor")
+            self.humidity.textColor = UIColor(named: "LabelTextColor")
+            self.contentStackView.backgroundColor = UIColor(named: "ViewControllerBackgroundColor")
+            self.rainStackView.backgroundColor = UIColor(named: "ViewControllerBackgroundColor")
+            self.humidityStackView.backgroundColor = UIColor(named: "ViewControllerBackgroundColor")
+            self.collectionView.backgroundColor = UIColor(named: "CollectionViewCellBackgroundColor")
+            self.view.backgroundColor = UIColor(named: "ViewControllerBackgroundColor")
+        }
     // 날씨 정보로 UI 그리기
     private func configureTexts(model: [WeatherModel]) {
         guard let element = model.first,

--- a/showWeather/showWeather/Controllers/WeatherViewController.swift
+++ b/showWeather/showWeather/Controllers/WeatherViewController.swift
@@ -118,8 +118,6 @@ class WeatherViewController: UIViewController {
             .observe(on: MainScheduler.instance)
             .asObservable()
             .subscribe(onNext: { [weak self] model in
-                print("viewModel bind")
-                print("model: \(model)")
                 self?.configureTexts(model: model)
             })
             .disposed(by: disposeBag)

--- a/showWeather/showWeather/DataModel/DataModel.swift
+++ b/showWeather/showWeather/DataModel/DataModel.swift
@@ -10,6 +10,7 @@ import Foundation
 struct LocationWeatherDataModel {
     let address: String
     let location: (nx: String, ny: String)
+    let savedDataModel: SavedWeatherDataModel?
 }
 struct SavedWeatherDataModel {
     let address: String

--- a/showWeather/showWeather/Extension/RxCocoaExtension.swift
+++ b/showWeather/showWeather/Extension/RxCocoaExtension.swift
@@ -1,0 +1,91 @@
+//
+//  RxCocoaExtension.swift
+//  showWeather
+//
+//  Created by 이민재 on 7/15/24.
+//
+
+import Foundation
+import RxSwift
+import RxCocoa
+import MapKit
+
+// MARK: MKLocalSearchCompleter Reactive Extension
+extension MKLocalSearchCompleter: HasDelegate {
+    public typealias Delegate = MKLocalSearchCompleterDelegate
+}
+
+class RxMKLocalSearchCompleterDelegateProxy: DelegateProxy<MKLocalSearchCompleter, MKLocalSearchCompleterDelegate>, DelegateProxyType, MKLocalSearchCompleterDelegate {
+    public weak private(set) var localSearchCompleter: MKLocalSearchCompleter?
+    
+    public init(localSearchCompleter: ParentObject) {
+        self.localSearchCompleter = localSearchCompleter
+        super.init(parentObject: localSearchCompleter,
+                   delegateProxy: RxMKLocalSearchCompleterDelegateProxy.self)
+    }
+    static func registerKnownImplementations() {
+        self.register { RxMKLocalSearchCompleterDelegateProxy(localSearchCompleter: $0)}
+    }
+    
+}
+extension Reactive where Base: MKLocalSearchCompleter {
+    
+    func castOrThrow<T>(_ resultType: T.Type, _ object: Any) throws -> T {
+        guard let returnValue = object as? T else {
+            throw RxCocoaError.castingError(object: object, targetType: resultType)
+        }
+        return returnValue
+    }
+    public var delegate: DelegateProxy<MKLocalSearchCompleter, MKLocalSearchCompleterDelegate> {
+        return RxMKLocalSearchCompleterDelegateProxy.proxy(for: base)
+    }
+    
+    public var didUpdateResults: ControlEvent<MKLocalSearchCompleter> {
+        let source = delegate
+            .methodInvoked(#selector(MKLocalSearchCompleterDelegate.completerDidUpdateResults(_:)))
+            .map { a in
+                return try castOrThrow(MKLocalSearchCompleter.self, a[0])
+            }
+        return ControlEvent(events: source)
+    }
+}
+
+
+// MARK: UISearchResultUpdating Reactive Extenstion
+extension Reactive where Base: UISearchController {
+    
+    var delegate: DelegateProxy<UISearchController, UISearchResultsUpdating> {
+        return RxSearchResultsUpdatingProxy.proxy(for: base)
+    }
+    
+    var searchPhrase: Observable<String> {
+        return RxSearchResultsUpdatingProxy.proxy(for: base).searchPhraseSubject.asObservable()
+    }
+}
+
+class RxSearchResultsUpdatingProxy: DelegateProxy<UISearchController, UISearchResultsUpdating>,DelegateProxyType, UISearchResultsUpdating {
+    
+    // DelegateProxyType
+    static func registerKnownImplementations() {
+        register { RxSearchResultsUpdatingProxy(searchController: $0) }
+    }
+    static func currentDelegate(for object: UISearchController) -> UISearchResultsUpdating? {
+        return object.searchResultsUpdater
+    }
+    static func setCurrentDelegate(_ delegate: UISearchResultsUpdating?, to object: UISearchController) {
+        object.searchResultsUpdater = delegate
+    }
+    
+    
+    lazy var searchPhraseSubject = PublishSubject<String>()
+    
+    init(searchController: UISearchController) {
+        super.init(parentObject: searchController, delegateProxy: RxSearchResultsUpdatingProxy.self)
+    }
+    
+    // UISearchResultsUpdating
+    func updateSearchResults(for searchController: UISearchController) {
+        searchPhraseSubject.onNext(searchController.searchBar.text ?? "")
+    }
+    
+}

--- a/showWeather/showWeather/ViewModels/SearchResultViewModel.swift
+++ b/showWeather/showWeather/ViewModels/SearchResultViewModel.swift
@@ -7,6 +7,8 @@
 
 import Foundation
 import MapKit
+import RxSwift
+import RxCocoa
 
 // 셀 자동완성 검색을 위한 Delegate
 protocol SearchResultViewModelDelegate: AnyObject {
@@ -14,17 +16,9 @@ protocol SearchResultViewModelDelegate: AnyObject {
 }
 class SearchResultViewModel {
     weak var delegate: SearchResultViewModelDelegate?
-    private(set) var elements: [SearchDataModel] = [] {
-        didSet {
-            delegate?.didChangedElements()
-        }
-    }
-    init() {
-        print("SRVM init")
-    }
-    var elementsCount: Int {
-        return self.elements.count
-    }
+    
+    private(set) var element = BehaviorRelay<[SearchDataModel]>(value: [])
+    
 //    데이터모델 형식에 맞춰서 변환
     func fetchData(_ arr: [MKLocalSearchCompletion]?) {
         guard let data = arr else { return }
@@ -32,9 +26,9 @@ class SearchResultViewModel {
         for element in data {
             converted.append(SearchDataModel(addressLabel: element.title, detailAddressLabel: element.subtitle))
         }
-        elements = converted
+        element.accept(converted)
     }
     func removeAllElements() {
-        self.elements.removeAll()
+        self.element.accept([])
     }
 }

--- a/showWeather/showWeather/ViewModels/ViewModel.swift
+++ b/showWeather/showWeather/ViewModels/ViewModel.swift
@@ -6,68 +6,46 @@
 //
 
 import Foundation
-// Delegate
-protocol ViewModelDelegate: AnyObject {
-    func savedWeathersUpdated()
-}
+import RxSwift
+import RxCocoa
+
 class ViewModel {
-    weak var delegate: ViewModelDelegate?
-    // 선택된 지역의 주소와 nx,ny가 저장된 데이터 모델: LocationWeatherDataModel
-    // 지역 추가시 해당 데이터모델을 불러와 네트워크 통신 후 SavedWeatherDataModel로 데이터변환
-    lazy var savedLocationWeatherDataModel: [LocationWeatherDataModel] = [] {
+    private let disposeBag = DisposeBag()
+    // 추가버튼 터치시 해당 데이터모델을 변환후 저장, 저장되면 savedWeather에 이벤트발생
+    private var saved: [LocationWeatherDataModel] = [] {
         didSet {
-            print("savedLocationWeatherDataModel didSet")
-            if !self.savedLocationWeatherDataModel.isEmpty {
-                if let last = self.savedLocationWeatherDataModel.last {
-                    fetchData(dataModel: last)
-                }
-            }
+            savedWeather.accept(self.saved)
         }
     }
-    // 데이터 변환시 ViewController에 델리게이트 패턴을 통해 알림
-    private(set) var savedWeathers: [SavedWeatherDataModel] = [] {
-        didSet {
-            delegate?.savedWeathersUpdated()
-            print("savedWeathers didSet")
-        }
-    }
+    private(set) var savedWeather = BehaviorRelay<[LocationWeatherDataModel]>(value: [])
     
-    // nx,ny로 네트워크 통신을 통해 날씨정보 "간편" 불러오기
-    // 2번을 불러오면 모든 데이터를 불러오지만, 한번만 불러와도 간편정보 모두를 가져올 수 있음. (convenience: true)
-    private func fetchData(dataModel: LocationWeatherDataModel) {
-        let nx = Int(dataModel.location.nx)!
-        let ny = Int(dataModel.location.ny)!
-        
-        APIManager.shared.dataFetch(nx: nx, ny: ny, convenience: true) { [weak self] result in
-            guard let self = self else { return }
-            switch result {
-            case .success(let data):
-                if let converted = self.convertData(address: dataModel.address, data: data) {
-                    print("converted success")
-                    self.savedWeathers.append(converted)
-                }
-            case .failure(.decodingError(error: let error)):
-                print("decodingError: \(error)")
-            case .failure(.invalidUrl):
-                print("invalidURL Error")
-            case .failure(.missingData):
-                print("missingData Error")
-            case .failure(.serverError(code: let code)):
-                print("serverError code: \(code)")
-            case .failure(.transportError):
-                print("transportError")
+    // WeatherVC에서 추가버튼 클릭시 델리게이트 패턴을 통해 VC에서 이 함수 실행
+    func saveData(model: LocationWeatherDataModel) {
+        let nx = Int(model.location.nx)!
+        let ny = Int(model.location.ny)!
+        APIManager.shared.getData(nx: nx, ny: ny, convenience: true)
+            .asObservable()
+            .map { [weak self] data in
+                return LocationWeatherDataModel(address: model.address,
+                                                location: model.location,
+                                                savedDataModel: self?.convertData(address: model.address, data: data))
             }
-        }
+            .subscribe{ [weak self] data in
+                guard let element = data.element else { return }
+                self?.saved.append(element)
+            }
+            .disposed(by: disposeBag)
     }
     
     // WeatherDataModel -> SavedWeatherDataModel 로 데이터 변환
-    private func convertData(address: String, data: WeatherDataModel) -> SavedWeatherDataModel? {
-        guard let fcstTime = data.response.body?.items.item[0].fcstTime else { return nil}
+    private func convertData(address: String, data: WeatherDataModel) -> SavedWeatherDataModel {
+        let failed = SavedWeatherDataModel(address: "", timeStamp: Date(), skyInfo: "", temperature: "", rainAmount: "")
+        guard let fcstTime = data.response.body?.items.item[0].fcstTime else { return failed}
         var converted = SavedWeatherDataModel(address: "", timeStamp: Date(), skyInfo: "", temperature: "", rainAmount: "")
         guard let rainAmount = data.response.body?.items.item.filter({$0.fcstTime == fcstTime && $0.category == "RN1"}).first?.fcstValue,
               let temperature = data.response.body?.items.item.filter({$0.fcstTime == fcstTime && $0.category == "T1H"}).first?.fcstValue,
               let sky = data.response.body?.items.item.filter({$0.fcstTime == fcstTime && $0.category == "SKY"}).first?.fcstValue
-        else { return nil }
+        else { return failed }
         
         var skyInfo = ""
         switch sky {

--- a/showWeather/showWeather/ViewModels/ViewModel.swift
+++ b/showWeather/showWeather/ViewModels/ViewModel.swift
@@ -23,16 +23,17 @@ class ViewModel {
     func saveData(model: LocationWeatherDataModel) {
         let nx = Int(model.location.nx)!
         let ny = Int(model.location.ny)!
-        APIManager.shared.getData(nx: nx, ny: ny, convenience: true)
-            .asObservable()
-            .map { [weak self] data in
-                return LocationWeatherDataModel(address: model.address,
-                                                location: model.location,
-                                                savedDataModel: self?.convertData(address: model.address, data: data))
-            }
-            .subscribe{ [weak self] data in
-                guard let element = data.element else { return }
-                self?.saved.append(element)
+        APIManager.shared.fetchData(nx: nx, ny: ny, page: 1)
+            .subscribe { [weak self] event in
+                switch event {
+                case .success(let data):
+                    let data = self?.convertData(address: model.address, data: data)
+                    self?.saved.append(LocationWeatherDataModel(address: model.address,
+                                                                location: model.location,
+                                                                savedDataModel: data))
+                case .failure(let error):
+                    print(error)
+                }
             }
             .disposed(by: disposeBag)
     }

--- a/showWeather/showWeather/ViewModels/WeatherViewModel.swift
+++ b/showWeather/showWeather/ViewModels/WeatherViewModel.swift
@@ -105,23 +105,35 @@ class WeatherViewModel {
             let location: LatXLngY = APIManager.shared.convertGRID_GPS(mode: 0, lat_X: lati, lng_Y: long)
             self.selectedLocation = (nx: String(location.x), ny: String(location.y))
             // Rx+URLSesison을 통한 네트워크 통신
-            APIManager.shared.getData(nx: location.x, ny: location.y, convenience: false)
-                .share(replay: 1,scope: .whileConnected)
-                .subscribe{[weak self] data in
-                    print("WeatherVM Rx Subscribe::")
-                    guard let element = data.element else { return }
-                    self?.convertDataFromCategory(response: element)
-                }
-                .disposed(by: self.disposeBag)
-
+            for i in 1...2 {
+                APIManager.shared.fetchData(nx: location.x, ny: location.y, page: i)
+                    .subscribe {[weak self] event in
+                        switch event {
+                        case .success(let data):
+                            print(data)
+                            self?.convertDataFromCategory(response: data)
+                        case .failure(let error):
+                            print(error)
+                        }
+                    }
+                    .disposed(by: disposeBag)
+            }
+            
         }
     }
     
     func fetchDataFromViewController(nx: Int, ny: Int) {
-        APIManager.shared.getData(nx: nx, ny: ny, convenience: false)
-            .subscribe{ [weak self] data in
-                self?.convertDataFromCategory(response: data)
-            }
-            .disposed(by: disposeBag)
+        for i in 1...2 {
+            APIManager.shared.fetchData(nx: nx, ny: ny, page: i)
+                .subscribe {[weak self] event in
+                    switch event {
+                    case .success(let data):
+                        self?.convertDataFromCategory(response: data)
+                    case .failure(let error):
+                        print(error)
+                    }
+                }
+                .disposed(by: disposeBag)
+        }
     }
 }

--- a/showWeather/showWeather/ViewModels/WeatherViewModel.swift
+++ b/showWeather/showWeather/ViewModels/WeatherViewModel.swift
@@ -105,35 +105,58 @@ class WeatherViewModel {
             let location: LatXLngY = APIManager.shared.convertGRID_GPS(mode: 0, lat_X: lati, lng_Y: long)
             self.selectedLocation = (nx: String(location.x), ny: String(location.y))
             // Rx+URLSesison을 통한 네트워크 통신
-            for i in 1...2 {
-                APIManager.shared.fetchData(nx: location.x, ny: location.y, page: i)
-                    .subscribe {[weak self] event in
-                        switch event {
+            let single1 = APIManager.shared.fetchData(nx: location.x, ny: location.y, page: 1)
+            let single2 = APIManager.shared.fetchData(nx: location.x, ny: location.y, page: 2)
+            
+            let zippedSingle = Single.zip(single1, single2)
+            zippedSingle
+                .subscribe {[weak self] event in
+                    switch event {
+                    case .success((let result1, let result2)):
+                        switch result1 {
                         case .success(let data):
-                            print(data)
                             self?.convertDataFromCategory(response: data)
                         case .failure(let error):
-                            print(error)
+                            print("page 1 error:\(error)")
                         }
+                        switch result2 {
+                        case .success(let data):
+                            self?.convertDataFromCategory(response: data)
+                        case .failure(let error):
+                            print("page 2 error:\(error)")
+                        }
+                    case .failure(let error):
+                        print("zipped single fail\(error)")
                     }
-                    .disposed(by: disposeBag)
-            }
+                }
             
         }
     }
     
     func fetchDataFromViewController(nx: Int, ny: Int) {
-        for i in 1...2 {
-            APIManager.shared.fetchData(nx: nx, ny: ny, page: i)
-                .subscribe {[weak self] event in
-                    switch event {
+        let single1 = APIManager.shared.fetchData(nx: nx, ny: ny, page: 1)
+        let single2 = APIManager.shared.fetchData(nx: nx, ny: ny, page: 2)
+        
+        let zippedSingle = Single.zip(single1, single2)
+        zippedSingle
+            .subscribe{[weak self] event in
+                switch event {
+                case .success((let result1, let result2)):
+                    switch result1 {
                     case .success(let data):
                         self?.convertDataFromCategory(response: data)
                     case .failure(let error):
-                        print(error)
+                        print("page 1 error:\(error)")
                     }
+                    switch result2 {
+                    case .success(let data):
+                        self?.convertDataFromCategory(response: data)
+                    case .failure(let error):
+                        print("page 2 error:\(error)")
+                    }
+                case .failure(let error):
+                    print("zipped single fail\(error)")
                 }
-                .disposed(by: disposeBag)
-        }
+            }
     }
 }

--- a/showWeather/showWeather/ViewModels/WeatherViewModel.swift
+++ b/showWeather/showWeather/ViewModels/WeatherViewModel.swift
@@ -98,19 +98,21 @@ class WeatherViewModel {
                 print(error?.localizedDescription)
                 return
             }
+            guard let self = self else { return }
             let places = response?.mapItems[0]
             guard let lati = places?.placemark.coordinate.latitude, let long = places?.placemark.coordinate.longitude else { return }
             // 불러온 위도 경도를 x좌표,y좌표로 변환
             let location: LatXLngY = APIManager.shared.convertGRID_GPS(mode: 0, lat_X: lati, lng_Y: long)
-            self?.selectedLocation = (nx: String(location.x), ny: String(location.y))
+            self.selectedLocation = (nx: String(location.x), ny: String(location.y))
             // Rx+URLSesison을 통한 네트워크 통신
             APIManager.shared.getData(nx: location.x, ny: location.y, convenience: false)
+                .share(replay: 1,scope: .whileConnected)
                 .subscribe{[weak self] data in
                     print("WeatherVM Rx Subscribe::")
                     guard let element = data.element else { return }
                     self?.convertDataFromCategory(response: element)
                 }
-                .disposed(by: self?.disposeBag ?? DisposeBag())
+                .disposed(by: self.disposeBag)
 
         }
     }

--- a/showWeather/showWeather/ViewModels/WeatherViewModel.swift
+++ b/showWeather/showWeather/ViewModels/WeatherViewModel.swift
@@ -81,7 +81,7 @@ class WeatherViewModel {
     func getLocationDataModel() -> LocationWeatherDataModel? {
         guard let location = self.selectedLocation else { return nil }
         let address = self.address
-        return LocationWeatherDataModel(address: address, location: location)
+        return LocationWeatherDataModel(address: address, location: location, savedDataModel: nil)
     }
     // MKLocalSearchRequest 생성 -> 선택된 지역의 정보 가져오기(위도,경도)
     func search(for suggestedCompletion: MKLocalSearchCompletion) {
@@ -103,7 +103,7 @@ class WeatherViewModel {
             // 불러온 위도 경도를 x좌표,y좌표로 변환
             let location: LatXLngY = APIManager.shared.convertGRID_GPS(mode: 0, lat_X: lati, lng_Y: long)
             self?.selectedLocation = (nx: String(location.x), ny: String(location.y))
-            // URLSesison을 통한 네트워크 통신
+            // Rx+URLSesison을 통한 네트워크 통신
             APIManager.shared.getData(nx: location.x, ny: location.y, convenience: false)
                 .subscribe{[weak self] data in
                     print("WeatherVM Rx Subscribe::")


### PR DESCRIPTION
- ViewController, ViewModel을 RxSwift 패턴으로 리팩토링 및 바인딩
- WeatherViewController, WeatherViewModel을 RxSwift 패턴으로 리팩토링 및 바인딩

느낀점)
예제로 보던 RxSwift 패턴은 코드의 가독성을 늘려주고 길이도 확 단축된다는데.. 어떻게 코드를 바꿔봐도 크게 달라지는게 없어보임..
아직 이론이 미숙해서 어디서부터 어디까지 반응형으로 구현해야하는지 감이 안잡힌다.
이전에는 CollectionView의 DataSource 프로토콜을 채택하여 Custom cell을 만들어 줬다면, CollectionView를 Subject와 바인딩해서
셀의 구성을 커스텀해준다.
그러면 Delegate 프로토콜을 채택하여 CollectionView의 flowlayout이나 이런 전체적인 모양은 RxCocoa로 리팩토링 할 수 없을까?
Subject는 많은 Observable과 연결이 된다하면 Delegate패턴을 사용하여 뷰컨간의 데이터전달을 리팩토링할 수 없을까?